### PR TITLE
Fixing incorrect usage of base_input for textarea widget in daisyui_field.py

### DIFF
--- a/crispy_daisyui/templatetags/daisyui_field.py
+++ b/crispy_daisyui/templatetags/daisyui_field.py
@@ -93,7 +93,7 @@ class CrispyDaisyUiFieldNode(template.Node):
         "multiplehidden": "",
         "file": "file-input file-input-bordered w-full focus:ring focus:outline-none",
         "clearablefile": "file-input file-input-bordered w-full focus:ring focus:outline-none",
-        "textarea": base_input,
+        "textarea": "textarea textarea-bordered w-full focus:ring focus:outline-none",
         "date": base_input,
         "datetime": base_input,
         "time": base_input,


### PR DESCRIPTION
## Description:

In this pull request, I fixed a line in daisyui_field.py where the base_input was being used for the textarea widget, which is incorrect (since textarea has its own HTML tag, instead of using the `input` tag).

I replaced it with the `textarea` classes, similar to other non-input widgets like `file-input`, to ensure the correct styling is applied to the textarea widget. This change will ensure consistency and correctness in the usage of classes for the textarea widget in daisyui_field.py. (Most notably, the `input` tag sets the `height` attribute of any input element to `3 em`, which conflicts with the `rows` attribute of `textarea`.

Did a quick visual inspection of this to confirm that it works (using a model form with a single text field and the `| crispy` filter.