### PR TITLE
Add missing id="..." to select.html

### DIFF
--- a/crispy_daisyui/templates/daisyui/layout/select.html
+++ b/crispy_daisyui/templates/daisyui/layout/select.html
@@ -1,7 +1,10 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<select class="select select-bordered w-full focus:ring focus:outline-none{% if field.errors %} select-error {% endif %}" name="{{ field.html_name }}" {{ field.field.widget.attrs|flatatt }}>
+<select class="select select-bordered w-full focus:ring focus:outline-none{% if field.errors %} select-error {% endif %}" 
+    name="{{ field.html_name }}" 
+    id="{% if input.id %}{{ input.id }}{% else %}{{ input.input_type }}-id-{{ input.name|slugify }}{% endif %}"
+    {{ field.field.widget.attrs|flatatt }}>
     {% for value, label in field.field.choices %}
         {% include "daisyui/layout/select_option.html" with value=value label=label %}
     {% endfor %}


### PR DESCRIPTION
The `<select>` tag, as provided in `select.html`, has no `id="..."` being set. This PR adds the field in the same way as it occurs in `baseinput.html`.