### PR TITLE
Fix checkbox label rendering in template

### DIFF
--- a/crispy_daisyui/templates/daisyui/layout/checkbox.html
+++ b/crispy_daisyui/templates/daisyui/layout/checkbox.html
@@ -2,12 +2,12 @@
 
 <div class="form-control">
   <label class="label cursor-pointer">
-    <span class="label-text">{{ field.label }}</span>
     <input type="checkbox" 
            class="checkbox {{ field.css_classes }}"
            name="{{ field.html_name }}"
            id="{{ field.auto_id }}"
            {% if field.value %}checked="checked"{% endif %}
            {{ field.field.widget.attrs|flatatt }}>
+    <span class="label-text">{{ field.label }}</span>
   </label>
 </div>


### PR DESCRIPTION
Based on checkbox conventions, the input field should come before the label. The current is very confusing for users, and it isn't a good practice. I recommend rendering it as in examples here - https://daisyui.com/components/checkbox/