### PR TITLE
Fix y spacing around checkboxes

### DIFF
--- a/crispy_daisyui/templates/daisyui/field.html
+++ b/crispy_daisyui/templates/daisyui/field.html
@@ -26,7 +26,7 @@
         {% include 'daisyui/layout/toggle.html' %}
         </div>
     {% elif field|is_checkbox %}
-        <div class="{% if field_class %}{{ field_class }}{% else %}mb-3{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+        <div class="{% if field_class %}{{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
         {% include 'daisyui/layout/checkbox.html' %}
         </div>
     {% elif field|is_radioselect %}

--- a/crispy_daisyui/templates/daisyui/layout/checkbox.html
+++ b/crispy_daisyui/templates/daisyui/layout/checkbox.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_filters %}
 
-<div class="form-control">
+<div class="form-control h-6">
   <label class="label cursor-pointer">
     <span class="label-text">{{ field.label }}</span>
     <input type="checkbox" 


### PR DESCRIPTION
Checkboxes had awkward excess spacing especially when using form labels. This PR fixes #14 

## Before

<img width="480" height="270" alt="Screenshot From 2026-02-05 18-23-23" src="https://github.com/user-attachments/assets/2e57b281-b505-47b4-8e17-0d287f09d348" />

## After

<img width="480" height="270" alt="Screenshot From 2026-02-05 18-24-10" src="https://github.com/user-attachments/assets/acc383a1-deba-4104-840f-e33f9691a2b0" />